### PR TITLE
remove not needed 'GetInfo(...)' call

### DIFF
--- a/screensaver.cpblobs/addon.xml.in
+++ b/screensaver.cpblobs/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.cpblobs"
-  version="1.1.0"
+  version="1.2.0"
   name="CpBlobs"
   provider-name="spiff">
   <requires>

--- a/src/cpBlobsMain.cpp
+++ b/src/cpBlobsMain.cpp
@@ -451,7 +451,3 @@ extern "C" void ADDON_FreeSettings()
 extern "C" void ADDON_Announce(const char *flag, const char *sender, const char *message, const void *data)
 {
 }
-
-extern "C" void GetInfo(SCR_INFO *info)
-{
-}


### PR DESCRIPTION
Remove of never used `GetInfo` function.

Related to https://github.com/xbmc/xbmc/pull/11190