### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix", platforms: ['android-armv7', 'android-aarch64', 'ios-aarch64', 'tvos-aarch64', 'osx-x86_64', 'ubuntu-ppa'])
+buildPlugin(version: "Nexus", platforms: ['android-armv7', 'android-aarch64', 'ios-aarch64', 'tvos-aarch64', 'osx-x86_64', 'ubuntu-ppa'])

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This is a [Kodi](http://kodi.tv) screensaver addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/xbmc/screensaver.cpblobs/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/screensaver.cpblobs/actions/workflows/build.yml)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/screensaver.cpblobs/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fscreensaver.cpblobs/branches/)
+[![Build and run tests](https://github.com/xbmc/screensaver.cpblobs/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/xbmc/screensaver.cpblobs/actions/workflows/build.yml)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/screensaver.cpblobs/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fscreensaver.cpblobs/branches/)
 
 ## Build instructions
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   branches:
     include:
     - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/screensaver.cpblobs/addon.xml.in
+++ b/screensaver.cpblobs/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="screensaver.cpblobs"
-  version="3.4.0"
+  version="20.0.0"
   name="CpBlobs"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to final released Kodi Matrix.

Further is the version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.